### PR TITLE
make rsync.js less verbose

### DIFF
--- a/lib/rsync.js
+++ b/lib/rsync.js
@@ -73,7 +73,7 @@ rsync.prototype.setup = function () {
         .set('checksum')
         .archive()
         .compress()
-        .progress()
+        //.progress() don't be so verbose
         .source(this.src)
         .destination(this.destination);
 


### PR DESCRIPTION
the log output is too huge - we only need the summary. 